### PR TITLE
Simplify

### DIFF
--- a/R/bfs_get_catalog.R
+++ b/R/bfs_get_catalog.R
@@ -1,7 +1,7 @@
 #' Get the Swiss Federal Statistical Office data catalog in a given language
-#' 
+#'
 #' This function scraps the RSS Feed of the Swiss Federal Statistical Office data catalog.
-#' 
+#'
 #' @param language character The language of a BFS catalog.
 #'
 #' @return A data frame
@@ -9,21 +9,27 @@
 #' @importFrom tidyRSS tidyfeed
 #' @importFrom janitor clean_names
 #' @importFrom dplyr select mutate
-#' 
+#'
 #' @seealso \code{\link{bfs_get_metadata}}
 #'
 #' @examples
 #' \donttest{bfs_get_catalog(language = "de")}
-#' 
+#'
 #' @export
 
 bfs_get_catalog <- function(language = c("de", "fr", "it", "en")) {
+  if (missing(language))
+    stop("must choose a language, either 'de', 'fr', 'it' or 'en'", call. = FALSE)
   
-  if(missing(language)) stop("must choose a language, either 'de', 'fr', 'it' or 'en'", call. = FALSE)
+  language <-
+    match.arg(arg = language, choices = c("de", "fr", "it", "en"))
   
-  language <- match.arg(arg = language, choices = c("de", "fr", "it", "en"))
-  
-  feed <- paste0("https://www.bfs.admin.ch/bfs/", language, "/home/statistiken/kataloge-datenbanken/daten/_jcr_content/par/ws_catalog.rss.xml?skipLimit=true")
+  feed <-
+    paste0(
+      "https://www.bfs.admin.ch/bfs/",
+      language,
+      "/home/statistiken/kataloge-datenbanken/daten/_jcr_content/par/ws_catalog.rss.xml?skipLimit=true"
+    )
   
   df <- tidyRSS::tidyfeed(feed = feed)
   
@@ -32,16 +38,24 @@ bfs_get_catalog <- function(language = c("de", "fr", "it", "en")) {
   
   df <- janitor::clean_names(df, "small_camel")
   
-  base_url_bfs <- paste0("https://www.bfs.admin.ch/content/bfs/", language, "/home/statistiken/kataloge-datenbanken/daten.assetdetail.")
+  base_url_bfs <-
+    paste0(
+      "https://www.bfs.admin.ch/content/bfs/",
+      language,
+      "/home/statistiken/kataloge-datenbanken/daten.assetdetail."
+    )
   base_url_px <- "https://www.bfs.admin.ch/bfsstatic/dam/assets/"
   
   df <- df %>%
-    dplyr::select(title = title_2, url_bfs = link_2, published = pubDate_2) %>%
+    dplyr::select(title = title_2,
+                  url_bfs = link_2,
+                  published = pubDate_2) %>%
     dplyr::mutate(language = language) %>%
-    dplyr::mutate(url_px = gsub(base_url_bfs, base_url_px, url_bfs),
-                  url_px = gsub(".html$", "/master", url_px)) %>%
+    dplyr::mutate(
+      url_px = gsub(base_url_bfs, base_url_px, url_bfs),
+      url_px = gsub(".html$", "/master", url_px)
+    ) %>%
     dplyr::select(title, language, published, url_bfs, url_px)
   
   return(df)
 }
-

--- a/R/main.R
+++ b/R/main.R
@@ -1,4 +1,17 @@
-utils::globalVariables(c(".", "pb", "url_px", "link_2", "pubDate_2", "published", "title", "title_2", "url_bfs", "url_p"))
+utils::globalVariables(
+  c(
+    ".",
+    "pb",
+    "url_px",
+    "link_2",
+    "pubDate_2",
+    "published",
+    "title",
+    "title_2",
+    "url_bfs",
+    "url_p"
+  )
+)
 env <- new.env(parent = emptyenv())
 
 #' Get metadata of a give url page
@@ -19,7 +32,6 @@ env <- new.env(parent = emptyenv())
 #' @importFrom pins pin pin_get board_register_local board_local_storage
 
 get_bfs_metadata <- function(url) {
-  
   html_data <- url %>%
     xml2::read_html() %>%
     rvest::html_nodes(".media-body")
@@ -28,17 +40,42 @@ get_bfs_metadata <- function(url) {
     rvest::html_nodes(".data") %>%
     rvest::html_text()
   
-  metadata_observation_period <- tryCatch(metadata_info[seq(1, length(metadata_info), 3)], error = function(e) NA)
-  metadata_observation_period <- iconv(metadata_observation_period, "latin1", "ASCII", sub="") # remove non-ASCII characters
-  metadata_observation_period <- gsub("Dargestellter Zeitraum: ", "", metadata_observation_period)
-  metadata_observation_period <- gsub("Priode d'observation: ", "", metadata_observation_period)
-  metadata_observation_period <- gsub("Periodo contemplato: ", "", metadata_observation_period)
-  metadata_observation_period <- gsub("Observation period: ", "", metadata_observation_period)
+  metadata_observation_period <-
+    tryCatch(
+      metadata_info[seq(1, length(metadata_info), 3)],
+      error = function(e)
+        NA
+    )
+  metadata_observation_period <-
+    iconv(metadata_observation_period, "latin1", "ASCII", sub = "") # remove non-ASCII characters
+  metadata_observation_period <-
+    gsub("Dargestellter Zeitraum: ", "", metadata_observation_period)
+  metadata_observation_period <-
+    gsub("Priode d'observation: ", "", metadata_observation_period)
+  metadata_observation_period <-
+    gsub("Periodo contemplato: ", "", metadata_observation_period)
+  metadata_observation_period <-
+    gsub("Observation period: ", "", metadata_observation_period)
   
-  source <- tryCatch(metadata_info[seq(2, length(metadata_info), 3)], error = function(e) NA)
+  source <-
+    tryCatch(
+      metadata_info[seq(2, length(metadata_info), 3)],
+      error = function(e)
+        NA
+    )
   
-  metadata_info3 <- tryCatch(metadata_info[seq(3, length(metadata_info), 3)], error = function(e) NA)
-  metadata_published <- tryCatch(gsub("[^0-9.-]", "", metadata_info3), error = function(e) NA)
+  metadata_info3 <-
+    tryCatch(
+      metadata_info[seq(3, length(metadata_info), 3)],
+      error = function(e)
+        NA
+    )
+  metadata_published <-
+    tryCatch(
+      gsub("[^0-9.-]", "", metadata_info3),
+      error = function(e)
+        NA
+    )
   
   metadata_title <- html_data %>%
     rvest::html_nodes("a") %>%
@@ -51,7 +88,9 @@ get_bfs_metadata <- function(url) {
   
   metadata_url_px <- metadata_href %>%
     gsub("[^0-9]", "", .) %>%
-    paste0("https://www.bfs.admin.ch/bfsstatic/dam/assets/", ., "/master")
+    paste0("https://www.bfs.admin.ch/bfsstatic/dam/assets/",
+           .,
+           "/master")
   
   df <- tibble::tibble(
     title = metadata_title,
@@ -75,25 +114,26 @@ get_bfs_metadata <- function(url) {
 get_bfs_metadata_all <- function(i) {
   env$pb$tick() # progress bar
   df_metadata <- get_bfs_metadata(i)
-  df_metadata_all <- rbind.data.frame(df_metadata,
-                                      tibble::tibble(
-                                        title = character(0),
-                                        observation_period = character(0),
-                                        published = character(0),
-                                        source = character(0),
-                                        url_bfs = character(0),
-                                        url_px = character(0)
-                                      )
+  df_metadata_all <- rbind.data.frame(
+    df_metadata,
+    tibble::tibble(
+      title = character(0),
+      observation_period = character(0),
+      published = character(0),
+      source = character(0),
+      url_bfs = character(0),
+      url_px = character(0)
+    )
   )
 }
 
 #' Download BFS metadata in a given language
 #'
 #' Returns a tibble containing the titles, publication dates,
-#' observation periods, data source, metadata webpage urls and download link urls 
-#' in a given language of the current public BFS datasets available. If the path of 
-#' the cache argument is not provided, the downloaded BFS dataset will be saved in 
-#' the default cache folder of the {pins} package. 
+#' observation periods, data source, metadata webpage urls and download link urls
+#' in a given language of the current public BFS datasets available. If the path of
+#' the cache argument is not provided, the downloaded BFS dataset will be saved in
+#' the default cache folder of the {pins} package.
 #'
 #' Languages availables are German ("de", as default), French ("fr"),
 #' Italian ("it") and English ("en"). Note that Italian and English BFS
@@ -101,8 +141,8 @@ get_bfs_metadata_all <- function(i) {
 #'
 #' The BFS metadata is saved in a local folder using the pins package. The
 #' function allows to download the BFS metadata only once per day in a given
-#' language. If the metadata has alread been downloaded in a given language 
-#' during the day, the existing dataset is loaded into R from the pins caching 
+#' language. If the metadata has alread been downloaded in a given language
+#' during the day, the existing dataset is loaded into R from the pins caching
 #' folder instead of downloading again the metadata from the BFS website.
 #'
 #' @param language character The language of the metadata.
@@ -118,74 +158,88 @@ get_bfs_metadata_all <- function(i) {
 #'
 #' @export
 
-bfs_get_metadata <- function(language = "de", path = pins::board_cache_path(), force = FALSE) {
-  
-  pins::board_register_local(cache = path) # pins temp folder by default
-  
-  # Do NOT download metadata again if metadata already downloaded today
-  bfs_metadata <- tryCatch(pins::pin_get(paste0("bfs_meta_", language), board = "local"), error = function(e) "Metadata not downloaded today")
-  bfs_metadata_today <- attr(bfs_metadata, "download_date") == Sys.Date()
-  
-  if(!isTRUE(bfs_metadata_today) | force == TRUE){
-  
-  # extract the number pages to load
-  bfs_loadpages <- function(url) {
-    html_number_pages <- url %>%
-      xml2::read_html() %>%
-      rvest::html_node(".pull-right") %>%
-      rvest::html_nodes(".separator-left") %>%
-      .[[2]] %>%
-      rvest::html_node("a") %>%
-      as.character() %>%
-      gsub("[^0-9.]", "", .) %>%
-      as.numeric(.)
+bfs_get_metadata <-
+  function(language = "de",
+           path = pins::board_cache_path(),
+           force = FALSE) {
+    pins::board_register_local(cache = path) # pins temp folder by default
     
-    c(0:html_number_pages)
+    # Do NOT download metadata again if metadata already downloaded today
+    bfs_metadata <-
+      tryCatch(
+        pins::pin_get(paste0("bfs_meta_", language), board = "local"),
+        error = function(e)
+          "Metadata not downloaded today"
+      )
+    bfs_metadata_today <-
+      attr(bfs_metadata, "download_date") == Sys.Date()
+    
+    if (!isTRUE(bfs_metadata_today) | force == TRUE) {
+      # extract the number pages to load
+      bfs_loadpages <- function(url) {
+        html_number_pages <- url %>%
+          xml2::read_html() %>%
+          rvest::html_node(".pull-right") %>%
+          rvest::html_nodes(".separator-left") %>%
+          .[[2]] %>%
+          rvest::html_node("a") %>%
+          as.character() %>%
+          gsub("[^0-9.]", "", .) %>%
+          as.numeric(.)
+        
+        c(0:html_number_pages)
+      }
+      
+      if (language == "de") {
+        url_de <-
+          "https://www.bfs.admin.ch/bfs/de/home/statistiken/kataloge-datenbanken/daten/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
+        url_all <- paste0(url_de, bfs_loadpages(url_de))
+      } else if (language == "fr") {
+        url_fr <-
+          "https://www.bfs.admin.ch/bfs/fr/home/statistiques/catalogues-banques-donnees/donnees/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
+        url_all <- paste0(url_fr, bfs_loadpages(url_fr))
+      } else if (language == "it") {
+        url_it <-
+          "https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati/dati/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
+        url_all <- paste0(url_it, bfs_loadpages(url_it))
+      } else if (language == "en") {
+        url_en <-
+          "https://www.bfs.admin.ch/bfs/en/home/statistics/catalogues-databases/data/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
+        url_all <- paste0(url_en, bfs_loadpages(url_en))
+      } else {
+        cat("Please select between the following languages: de, fr, it, en")
+      }
+      
+      env$pb <- progress::progress_bar$new(format = "  downloading [:bar] :percent in :elapsed",
+                                           total = length(url_all),
+                                           clear = FALSE)
+      
+      bfs_metadata <- purrr::map_dfr(url_all, get_bfs_metadata_all) %>%
+        tibble::as_tibble()
+      
+      attr(bfs_metadata, "download_date") <- Sys.Date()
+      
+      pins::pin(bfs_metadata,
+                name = paste0("bfs_meta_", language),
+                board = "local")
+      
+      rm(pb, envir = env)
+      
+    }
+    
+    bfs_metadata <-
+      pins::pin_get(paste0("bfs_meta_", language), board = "local")
+    
+    return(bfs_metadata)
   }
-  
-  if (language == "de") {
-    url_de <- "https://www.bfs.admin.ch/bfs/de/home/statistiken/kataloge-datenbanken/daten/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
-    url_all <- paste0(url_de, bfs_loadpages(url_de))
-  } else if (language == "fr") {
-    url_fr <- "https://www.bfs.admin.ch/bfs/fr/home/statistiques/catalogues-banques-donnees/donnees/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
-    url_all <- paste0(url_fr, bfs_loadpages(url_fr))
-  } else if (language == "it") {
-    url_it <- "https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati/dati/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
-    url_all <- paste0(url_it, bfs_loadpages(url_it))
-  } else if (language == "en") {
-    url_en <- "https://www.bfs.admin.ch/bfs/en/home/statistics/catalogues-databases/data/_jcr_content/par/ws_catalog.dynamiclist.html?pageIndex="
-    url_all <- paste0(url_en, bfs_loadpages(url_en))
-  } else {
-    cat("Please select between the following languages: de, fr, it, en")
-  }
-  
-  env$pb <- progress::progress_bar$new(
-    format = "  downloading [:bar] :percent in :elapsed",
-    total = length(url_all), clear = FALSE)
-  
-  bfs_metadata <- purrr::map_dfr(url_all, get_bfs_metadata_all) %>%
-    tibble::as_tibble()
-  
-  attr(bfs_metadata, "download_date") <- Sys.Date()
-  
-  pins::pin(bfs_metadata, name = paste0("bfs_meta_", language), board = "local")
-  
-  rm(pb, envir = env)
-  
-  }
-  
-  bfs_metadata <- pins::pin_get(paste0("bfs_meta_", language), board = "local")
-  
-  return(bfs_metadata)
-}
 
 #' Search titles of available BFS datasets
 #'
 #' Returns a tibble containing the titles, publication date,
 #' observation periods, data source, metadata url and download urls of
 #' available BFS datasets in a given language which match
-#' the given criteria. This function leverages the R base function \code{grepl} 
-#' but calls the data argument first to allow the use of the pipe operator from 
+#' the given criteria. This function leverages the R base function \code{grepl}
+#' but calls the data argument first to allow the use of the pipe operator from
 #' magrittr.
 #'
 #' @param data The data frame to search. This can be either a data frame
@@ -206,24 +260,31 @@ bfs_get_metadata <- function(language = "de", path = pins::board_cache_path(), f
 #'
 #' @export
 
-bfs_search <- function(data = bfs_get_metadata(), pattern, ignore.case = TRUE, fixed = FALSE) {
-  data[grepl(pattern, data$title, ignore.case = ignore.case, fixed = fixed), ]
-}
+bfs_search <-
+  function(data = bfs_get_metadata(),
+           pattern,
+           ignore.case = TRUE,
+           fixed = FALSE) {
+    data[grepl(pattern,
+               data$title,
+               ignore.case = ignore.case,
+               fixed = fixed),]
+  }
 
 #' Download BFS dataset in a given language
 #'
-#' Returns a data frame/tibble from  the URL of a given BFS PC-Axis file. 
-#' The default language is German and the column names are renamed 
+#' Returns a data frame/tibble from  the URL of a given BFS PC-Axis file.
+#' The default language is German and the column names are renamed
 #' using the \code{\link[janitor]{clean_names}} function of the
-#' janitor package. If the path of the cache argument is not provided, the 
-#' downloaded BFS dataset will be saved in the default cache 
+#' janitor package. If the path of the cache argument is not provided, the
+#' downloaded BFS dataset will be saved in the default cache
 #' folder of the {pins} package. The metadata can be accessed by making the
 #' downloaded dataset an argument of the base R function \code{attributes()}.
 #'
 #' The BFS data is saved in a local folder using the pins package. The
-#' function allows to download the BFS data only once per day. If the data 
-#' has alread been downloaded during the day, the existing dataset is loaded 
-#' into R from the pins caching folder instead of downloading again the 
+#' function allows to download the BFS data only once per day. If the data
+#' has alread been downloaded during the day, the existing dataset is loaded
+#' into R from the pins caching folder instead of downloading again the
 #' data from the BFS website.
 #'
 #' @param url_px The url link to download the PC-Axis file.
@@ -236,258 +297,392 @@ bfs_search <- function(data = bfs_get_metadata(), pattern, ignore.case = TRUE, f
 #'
 #' @export
 
-bfs_get_dataset <- function(url_px, language = "de", path = pins::board_cache_path(), clean_names = TRUE, force = FALSE) {
-  pins::board_register_local(cache = path) # temp folder of the spins package
-  dataset_name <- paste0("bfs_data_", gsub("[^0-9]", "", url_px), "_", language)
-  tempfile_path <- paste0(tempdir(), "\\", dataset_name, ".px") # normal temp folder
-  
-  # Do NOT download data again if data already downloaded today
-  bfs_data <- tryCatch(pins::pin_get(dataset_name, board = "local"), error = function(e) "Data not downloaded today")
-  bfs_data_today <- attr(bfs_data, "download_date") == Sys.Date()
-  
-  if(!isTRUE(bfs_data_today) & language == "de" | force == TRUE & language == "de"){
-    download.file(url_px, destfile = file.path(tempfile_path))
-    # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
-    x <- iconv(readLines(file.path(tempfile_path), encoding = "CP1252"), from = "CP1252", to = "Latin1", sub = "")
-    x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
-    x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
-    writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
-    # END FIX
-    bfs_px <- pxR::read.px(file.path(tempfile_path), na.strings = c('"."', '".."', '"..."', '"...."', '"....."', '"......"', '":"'))
-    bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
+bfs_get_dataset <-
+  function(url_px,
+           language = "de",
+           path = pins::board_cache_path(),
+           clean_names = TRUE,
+           force = FALSE) {
+    pins::board_register_local(cache = path) # temp folder of the spins package
+    dataset_name <-
+      paste0("bfs_data_", gsub("[^0-9]", "", url_px), "_", language)
+    tempfile_path <-
+      paste0(tempdir(), "\\", dataset_name, ".px") # normal temp folder
     
-    if(clean_names){
-      bfs_data <- janitor::clean_names(bfs_data)
-    }
+    # Do NOT download data again if data already downloaded today
+    bfs_data <-
+      tryCatch(
+        pins::pin_get(dataset_name, board = "local"),
+        error = function(e)
+          "Data not downloaded today"
+      )
+    bfs_data_today <- attr(bfs_data, "download_date") == Sys.Date()
     
-    attr(bfs_data, "download_date") <- Sys.Date()
-    attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
-    attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
-    attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-    attr(bfs_data, "link") <- bfs_px$LINK[[1]]
-    attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
-    attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
-    attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
-    attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
-    attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
-    attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
-    
-    languages_availables <- strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
-    if(!is.element(language, languages_availables)) cat(paste0('Language "', language, '" not available. Dataset downloaded in the default language. Try with another language.'))
-    
-    attr(bfs_data, "download_date") <- Sys.Date()
-    attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
-    attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
-    attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-    attr(bfs_data, "link") <- bfs_px$LINK[[1]]
-    attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
-    attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
-    attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
-    attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
-    attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
-    attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
-
-    pins::pin(bfs_data, name = paste0(dataset_name), board = "local")
-  } else if (!isTRUE(bfs_data_today) & language == "fr" | force == TRUE & language == "fr") {
-    download.file(url_px, destfile = file.path(tempfile_path))
-    # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
-    x <- iconv(readLines(file.path(tempfile_path), encoding = "CP1252"), from = "CP1252", to = "Latin1", sub = "")
-    x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
-    x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
-    writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
-    # END FIX
-    bfs_px <- pxR::read.px(file.path(tempfile_path), na.strings = c('"."', '".."', '"..."', '"...."', '"....."', '"......"', '":"'))
-    bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
-    
-    attr(bfs_data, "download_date") <- Sys.Date()
-    attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
-    attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
-    attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-    attr(bfs_data, "link") <- bfs_px$LINK[[1]]
-    attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
-    attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
-    attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
-    attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
-    attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
-    attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
-    
-    languages_availables <- strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
-    if(!is.element(language, languages_availables)) cat(paste0('Language "', language, '" not available. Dataset downloaded in the default language. Try with another language.'))
-    
-    if(is.element(language, languages_availables)){
-      default_names <- names(bfs_px$VALUES)
-      new_names <- names(bfs_px$VALUES.fr.)
-      n_names <- length(default_names)
+    if (!isTRUE(bfs_data_today) &
+        language == "de" | force == TRUE & language == "de") {
+      download.file(url_px, destfile = file.path(tempfile_path))
+      # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
+      x <-
+        iconv(
+          readLines(file.path(tempfile_path), encoding = "CP1252"),
+          from = "CP1252",
+          to = "Latin1",
+          sub = ""
+        )
+      x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
+      x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
+      writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
+      # END FIX
+      bfs_px <-
+        pxR::read.px(
+          file.path(tempfile_path),
+          na.strings = c(
+            '"."',
+            '".."',
+            '"..."',
+            '"...."',
+            '"....."',
+            '"......"',
+            '":"'
+          )
+        )
+      bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
       
-      # ! possible bugs in new_categories
-      new_categories <- gsub('\", \"', "\n", bfs_px$VALUES.fr.)
-      new_categories <- gsub('\",\"', "\n", new_categories)
-      new_categories <- gsub(' \"', "", new_categories)
-      new_categories <- strsplit(new_categories, "\n")
-      
-      for(i in 1:n_names) {
-        tryCatch({
-          names(bfs_data)[names(bfs_data) == default_names[[i]]] <- new_names[i]
-          l <- as.name(new_names[[i]])
-          levels(bfs_data[[l]]) <- new_categories[[i]]
-          replace(bfs_data[[l]], unique(bfs_data[[l]]), new_categories[[i]])
-        }, error= function(e) {cat("Failed to translate name.", "\n")
-        })
-      }
-      
-      if(clean_names){
+      if (clean_names) {
         bfs_data <- janitor::clean_names(bfs_data)
       }
       
       attr(bfs_data, "download_date") <- Sys.Date()
-      attr(bfs_data, "contact") <- bfs_px$CONTACT.fr.[[1]]
-      attr(bfs_data, "description") <- bfs_px$DESCRIPTION.fr.[[1]]
+      attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
+      attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
       attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-      attr(bfs_data, "link") <- bfs_px$LINK.fr.[[1]]
-      attr(bfs_data, "note") <- bfs_px$NOTE.fr.[[1]]
-      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA.fr.[[1]]
-      attr(bfs_data, "survey") <- bfs_px$SURVEY.fr.[[1]]
-      attr(bfs_data, "title") <- bfs_px$TITLE.fr.[[1]]
-      attr(bfs_data, "source") <- bfs_px$SOURCE.fr.[[1]]
-      attr(bfs_data, "units") <- bfs_px$UNITS.fr.[[1]]
-    }
-    pins::pin(bfs_data, name = paste0(dataset_name), board = "local")
-    
-  } else if (!isTRUE(bfs_data_today) & language == "it" | force == TRUE & language == "it") {
-    download.file(url_px, destfile = file.path(tempfile_path))
-    # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
-    x <- iconv(readLines(file.path(tempfile_path), encoding = "CP1252"), from = "CP1252", to = "Latin1", sub = "")
-    x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
-    x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
-    writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
-    # END FIX
-    bfs_px <- pxR::read.px(file.path(tempfile_path), na.strings = c('"."', '".."', '"..."', '"...."', '"....."', '"......"', '":"'))
-    bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
-    
-    attr(bfs_data, "download_date") <- Sys.Date()
-    attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
-    attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
-    attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-    attr(bfs_data, "link") <- bfs_px$LINK[[1]]
-    attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
-    attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
-    attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
-    attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
-    attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
-    attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
-    
-    languages_availables <- strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
-    if(!is.element(language, languages_availables)) cat(paste0('Language "', language, '" not available. Dataset downloaded in the default language. Try with another language.'))
-    
-    if(is.element(language, languages_availables)){
-      default_names <- names(bfs_px$VALUES)
-      new_names <- names(bfs_px$VALUES.it.)
-      n_names <- length(default_names)
+      attr(bfs_data, "link") <- bfs_px$LINK[[1]]
+      attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
+      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
+      attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
+      attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
+      attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
+      attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
       
-      # ! possible bugs in new_categories
-      new_categories <- gsub('\", \"', "\n", bfs_px$VALUES.it.)
-      new_categories <- gsub('\",\"', "\n", new_categories)
-      new_categories <- gsub(' \"', "", new_categories)
-      new_categories <- strsplit(new_categories, "\n")
-      
-      for(i in 1:n_names) {
-        tryCatch({
-          names(bfs_data)[names(bfs_data) == default_names[[i]]] <- new_names[i]
-          l <- as.name(new_names[[i]])
-          levels(bfs_data[[l]]) <- new_categories[[i]]
-          replace(bfs_data[[l]], unique(bfs_data[[l]]), new_categories[[i]])
-        }, error= function(e) {cat("Failed to translate name.", "\n")
-        })
-      }
-    
-      if(clean_names){
-        bfs_data <- janitor::clean_names(bfs_data)
-      }
+      languages_availables <-
+        strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
+      if (!is.element(language, languages_availables))
+        cat(
+          paste0(
+            'Language "',
+            language,
+            '" not available. Dataset downloaded in the default language. Try with another language.'
+          )
+        )
       
       attr(bfs_data, "download_date") <- Sys.Date()
-      attr(bfs_data, "contact") <- bfs_px$CONTACT.it.[[1]]
-      attr(bfs_data, "description") <- bfs_px$DESCRIPTION.it.[[1]]
+      attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
+      attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
       attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-      attr(bfs_data, "link") <- bfs_px$LINK.it.[[1]]
-      attr(bfs_data, "note") <- bfs_px$NOTE.it.[[1]]
-      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA.it.[[1]]
-      attr(bfs_data, "survey") <- bfs_px$SURVEY.it.[[1]]
-      attr(bfs_data, "title") <- bfs_px$TITLE.it.[[1]]
-      attr(bfs_data, "source") <- bfs_px$SOURCE.it.[[1]]
-      attr(bfs_data, "units") <- bfs_px$UNITS.it.[[1]]
-    }
-    pins::pin(bfs_data, name = paste0(dataset_name), board = "local")
-    
-  } else if (!isTRUE(bfs_data_today) & language == "en" | force == TRUE & language == "en") {
-    download.file(url_px, destfile = file.path(tempfile_path))
-    # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
-    x <- iconv(readLines(file.path(tempfile_path), encoding = "CP1252"), from = "CP1252", to = "Latin1", sub = "")
-    x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
-    x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
-    writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
-    # END FIX
-    bfs_px <- pxR::read.px(file.path(tempfile_path), na.strings = c('"."', '".."', '"..."', '"...."', '"....."', '"......"', '":"'))
-    bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
-    
-    attr(bfs_data, "download_date") <- Sys.Date()
-    attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
-    attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
-    attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-    attr(bfs_data, "link") <- bfs_px$LINK[[1]]
-    attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
-    attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
-    attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
-    attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
-    attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
-    attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
-    
-    languages_availables <- strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
-    if(!is.element(language, languages_availables)) cat(paste0('Language "', language, '" not available. Dataset downloaded in the default language. Try with another language.'))
-    
-    if(is.element(language, languages_availables)){
-      default_names <- names(bfs_px$VALUES)
-      new_names <- names(bfs_px$VALUES.en.)
-      n_names <- length(default_names)
+      attr(bfs_data, "link") <- bfs_px$LINK[[1]]
+      attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
+      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
+      attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
+      attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
+      attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
+      attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
       
-      # ! possible bugs in new_categories
-      new_categories <- gsub('\", \"', "\n", bfs_px$VALUES.en.)
-      new_categories <- gsub('\",\"', "\n", new_categories)
-      new_categories <- gsub(' \"', "", new_categories)
-      new_categories <- strsplit(new_categories, "\n")
-      
-      for(i in 1:n_names) {
-        tryCatch({
-          names(bfs_data)[names(bfs_data) == default_names[[i]]] <- new_names[i]
-          l <- as.name(new_names[[i]])
-          levels(bfs_data[[l]]) <- new_categories[[i]]
-          replace(bfs_data[[l]], unique(bfs_data[[l]]), new_categories[[i]])
-        }, error= function(e) {cat("Failed to translate name.", "\n")
-      })
-      }
-      
-      if(clean_names){
-        bfs_data <- janitor::clean_names(bfs_data)
-      }
+      pins::pin(bfs_data,
+                name = paste0(dataset_name),
+                board = "local")
+    } else if (!isTRUE(bfs_data_today) &
+               language == "fr" | force == TRUE & language == "fr") {
+      download.file(url_px, destfile = file.path(tempfile_path))
+      # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
+      x <-
+        iconv(
+          readLines(file.path(tempfile_path), encoding = "CP1252"),
+          from = "CP1252",
+          to = "Latin1",
+          sub = ""
+        )
+      x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
+      x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
+      writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
+      # END FIX
+      bfs_px <-
+        pxR::read.px(
+          file.path(tempfile_path),
+          na.strings = c(
+            '"."',
+            '".."',
+            '"..."',
+            '"...."',
+            '"....."',
+            '"......"',
+            '":"'
+          )
+        )
+      bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
       
       attr(bfs_data, "download_date") <- Sys.Date()
-      attr(bfs_data, "contact") <- bfs_px$CONTACT.en.[[1]]
-      attr(bfs_data, "description") <- bfs_px$DESCRIPTION.en.[[1]]
+      attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
+      attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
       attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
-      attr(bfs_data, "link") <- bfs_px$LINK.en.[[1]]
-      attr(bfs_data, "note") <- bfs_px$NOTE.en.[[1]]
-      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA.en.[[1]]
-      attr(bfs_data, "survey") <- bfs_px$SURVEY.en.[[1]]
-      attr(bfs_data, "title") <- bfs_px$TITLE.en.[[1]]
-      attr(bfs_data, "source") <- bfs_px$SOURCE.en.[[1]]
-      attr(bfs_data, "units") <- bfs_px$UNITS.en.[[1]]
+      attr(bfs_data, "link") <- bfs_px$LINK[[1]]
+      attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
+      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
+      attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
+      attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
+      attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
+      attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
+      
+      languages_availables <-
+        strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
+      if (!is.element(language, languages_availables))
+        cat(
+          paste0(
+            'Language "',
+            language,
+            '" not available. Dataset downloaded in the default language. Try with another language.'
+          )
+        )
+      
+      if (is.element(language, languages_availables)) {
+        default_names <- names(bfs_px$VALUES)
+        new_names <- names(bfs_px$VALUES.fr.)
+        n_names <- length(default_names)
+        
+        # ! possible bugs in new_categories
+        new_categories <- gsub('\", \"', "\n", bfs_px$VALUES.fr.)
+        new_categories <- gsub('\",\"', "\n", new_categories)
+        new_categories <- gsub(' \"', "", new_categories)
+        new_categories <- strsplit(new_categories, "\n")
+        
+        for (i in 1:n_names) {
+          tryCatch({
+            names(bfs_data)[names(bfs_data) == default_names[[i]]] <-
+              new_names[i]
+            l <- as.name(new_names[[i]])
+            levels(bfs_data[[l]]) <- new_categories[[i]]
+            replace(bfs_data[[l]], unique(bfs_data[[l]]), new_categories[[i]])
+          }, error = function(e) {
+            cat("Failed to translate name.", "\n")
+          })
+        }
+        
+        if (clean_names) {
+          bfs_data <- janitor::clean_names(bfs_data)
+        }
+        
+        attr(bfs_data, "download_date") <- Sys.Date()
+        attr(bfs_data, "contact") <- bfs_px$CONTACT.fr.[[1]]
+        attr(bfs_data, "description") <- bfs_px$DESCRIPTION.fr.[[1]]
+        attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
+        attr(bfs_data, "link") <- bfs_px$LINK.fr.[[1]]
+        attr(bfs_data, "note") <- bfs_px$NOTE.fr.[[1]]
+        attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA.fr.[[1]]
+        attr(bfs_data, "survey") <- bfs_px$SURVEY.fr.[[1]]
+        attr(bfs_data, "title") <- bfs_px$TITLE.fr.[[1]]
+        attr(bfs_data, "source") <- bfs_px$SOURCE.fr.[[1]]
+        attr(bfs_data, "units") <- bfs_px$UNITS.fr.[[1]]
+      }
+      pins::pin(bfs_data,
+                name = paste0(dataset_name),
+                board = "local")
+      
+    } else if (!isTRUE(bfs_data_today) &
+               language == "it" | force == TRUE & language == "it") {
+      download.file(url_px, destfile = file.path(tempfile_path))
+      # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
+      x <-
+        iconv(
+          readLines(file.path(tempfile_path), encoding = "CP1252"),
+          from = "CP1252",
+          to = "Latin1",
+          sub = ""
+        )
+      x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
+      x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
+      writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
+      # END FIX
+      bfs_px <-
+        pxR::read.px(
+          file.path(tempfile_path),
+          na.strings = c(
+            '"."',
+            '".."',
+            '"..."',
+            '"...."',
+            '"....."',
+            '"......"',
+            '":"'
+          )
+        )
+      bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
+      
+      attr(bfs_data, "download_date") <- Sys.Date()
+      attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
+      attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
+      attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
+      attr(bfs_data, "link") <- bfs_px$LINK[[1]]
+      attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
+      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
+      attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
+      attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
+      attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
+      attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
+      
+      languages_availables <-
+        strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
+      if (!is.element(language, languages_availables))
+        cat(
+          paste0(
+            'Language "',
+            language,
+            '" not available. Dataset downloaded in the default language. Try with another language.'
+          )
+        )
+      
+      if (is.element(language, languages_availables)) {
+        default_names <- names(bfs_px$VALUES)
+        new_names <- names(bfs_px$VALUES.it.)
+        n_names <- length(default_names)
+        
+        # ! possible bugs in new_categories
+        new_categories <- gsub('\", \"', "\n", bfs_px$VALUES.it.)
+        new_categories <- gsub('\",\"', "\n", new_categories)
+        new_categories <- gsub(' \"', "", new_categories)
+        new_categories <- strsplit(new_categories, "\n")
+        
+        for (i in 1:n_names) {
+          tryCatch({
+            names(bfs_data)[names(bfs_data) == default_names[[i]]] <-
+              new_names[i]
+            l <- as.name(new_names[[i]])
+            levels(bfs_data[[l]]) <- new_categories[[i]]
+            replace(bfs_data[[l]], unique(bfs_data[[l]]), new_categories[[i]])
+          }, error = function(e) {
+            cat("Failed to translate name.", "\n")
+          })
+        }
+        
+        if (clean_names) {
+          bfs_data <- janitor::clean_names(bfs_data)
+        }
+        
+        attr(bfs_data, "download_date") <- Sys.Date()
+        attr(bfs_data, "contact") <- bfs_px$CONTACT.it.[[1]]
+        attr(bfs_data, "description") <- bfs_px$DESCRIPTION.it.[[1]]
+        attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
+        attr(bfs_data, "link") <- bfs_px$LINK.it.[[1]]
+        attr(bfs_data, "note") <- bfs_px$NOTE.it.[[1]]
+        attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA.it.[[1]]
+        attr(bfs_data, "survey") <- bfs_px$SURVEY.it.[[1]]
+        attr(bfs_data, "title") <- bfs_px$TITLE.it.[[1]]
+        attr(bfs_data, "source") <- bfs_px$SOURCE.it.[[1]]
+        attr(bfs_data, "units") <- bfs_px$UNITS.it.[[1]]
+      }
+      pins::pin(bfs_data,
+                name = paste0(dataset_name),
+                board = "local")
+      
+    } else if (!isTRUE(bfs_data_today) &
+               language == "en" | force == TRUE & language == "en") {
+      download.file(url_px, destfile = file.path(tempfile_path))
+      # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
+      x <-
+        iconv(
+          readLines(file.path(tempfile_path), encoding = "CP1252"),
+          from = "CP1252",
+          to = "Latin1",
+          sub = ""
+        )
+      x <- gsub('\"......\"', '\"....\"', x, fixed = TRUE)
+      x <- gsub('\".....\"', '\"....\"', x, fixed = TRUE)
+      writeLines(x, con = file.path(tempfile_path), useBytes = TRUE)
+      # END FIX
+      bfs_px <-
+        pxR::read.px(
+          file.path(tempfile_path),
+          na.strings = c(
+            '"."',
+            '".."',
+            '"..."',
+            '"...."',
+            '"....."',
+            '"......"',
+            '":"'
+          )
+        )
+      bfs_data <- tibble::as_tibble(as.data.frame(bfs_px))
+      
+      attr(bfs_data, "download_date") <- Sys.Date()
+      attr(bfs_data, "contact") <- bfs_px$CONTACT[[1]]
+      attr(bfs_data, "description") <- bfs_px$DESCRIPTION[[1]]
+      attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
+      attr(bfs_data, "link") <- bfs_px$LINK[[1]]
+      attr(bfs_data, "note") <- bfs_px$NOTE[[1]]
+      attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA[[1]]
+      attr(bfs_data, "survey") <- bfs_px$SURVEY[[1]]
+      attr(bfs_data, "title") <- bfs_px$TITLE[[1]]
+      attr(bfs_data, "source") <- bfs_px$SOURCE[[1]]
+      attr(bfs_data, "units") <- bfs_px$UNITS[[1]]
+      
+      languages_availables <-
+        strsplit(bfs_px$LANGUAGES[[1]], '\",\"', "\n")[[1]]
+      if (!is.element(language, languages_availables))
+        cat(
+          paste0(
+            'Language "',
+            language,
+            '" not available. Dataset downloaded in the default language. Try with another language.'
+          )
+        )
+      
+      if (is.element(language, languages_availables)) {
+        default_names <- names(bfs_px$VALUES)
+        new_names <- names(bfs_px$VALUES.en.)
+        n_names <- length(default_names)
+        
+        # ! possible bugs in new_categories
+        new_categories <- gsub('\", \"', "\n", bfs_px$VALUES.en.)
+        new_categories <- gsub('\",\"', "\n", new_categories)
+        new_categories <- gsub(' \"', "", new_categories)
+        new_categories <- strsplit(new_categories, "\n")
+        
+        for (i in 1:n_names) {
+          tryCatch({
+            names(bfs_data)[names(bfs_data) == default_names[[i]]] <-
+              new_names[i]
+            l <- as.name(new_names[[i]])
+            levels(bfs_data[[l]]) <- new_categories[[i]]
+            replace(bfs_data[[l]], unique(bfs_data[[l]]), new_categories[[i]])
+          }, error = function(e) {
+            cat("Failed to translate name.", "\n")
+          })
+        }
+        
+        if (clean_names) {
+          bfs_data <- janitor::clean_names(bfs_data)
+        }
+        
+        attr(bfs_data, "download_date") <- Sys.Date()
+        attr(bfs_data, "contact") <- bfs_px$CONTACT.en.[[1]]
+        attr(bfs_data, "description") <- bfs_px$DESCRIPTION.en.[[1]]
+        attr(bfs_data, "last_update") <- bfs_px$LAST.UPDATED[[1]]
+        attr(bfs_data, "link") <- bfs_px$LINK.en.[[1]]
+        attr(bfs_data, "note") <- bfs_px$NOTE.en.[[1]]
+        attr(bfs_data, "subject_area") <- bfs_px$SUBJECT.AREA.en.[[1]]
+        attr(bfs_data, "survey") <- bfs_px$SURVEY.en.[[1]]
+        attr(bfs_data, "title") <- bfs_px$TITLE.en.[[1]]
+        attr(bfs_data, "source") <- bfs_px$SOURCE.en.[[1]]
+        attr(bfs_data, "units") <- bfs_px$UNITS.en.[[1]]
+      }
+      pins::pin(bfs_data,
+                name = paste0(dataset_name),
+                board = "local")
     }
-    pins::pin(bfs_data, name = paste0(dataset_name), board = "local")
+    
+    bfs_data <- pins::pin_get(dataset_name, board = "local")
+    
+    return(bfs_data)
   }
-  
-  bfs_data <- pins::pin_get(dataset_name, board = "local")
-  
-  return(bfs_data)
-}
 
 #' Open folder containing all downloaded BFS datasets
 #'
@@ -505,8 +700,8 @@ bfs_get_dataset <- function(url_px, language = "de", path = pins::board_cache_pa
 #'
 #' @export
 
-bfs_open_dir <- function(path = pins::board_local_storage()){
-  if (.Platform['OS.type'] == "windows"){
+bfs_open_dir <- function(path = pins::board_local_storage()) {
+  if (.Platform['OS.type'] == "windows") {
     shell.exec(path)
   } else {
     system(paste(Sys.getenv("R_BROWSER"), path))

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,36 @@
+# source: https://github.com/r-hub/pkgsearch/blob/master/R/utils.R
+
+check_string <- function(x) {
+  if (!is.character(x) || length(x) != 1 || is.na(x)) {
+    throw(new_error(x, " is not a string", call. = FALSE))
+  }
+}
+
 `%+%` <- function(lhs, rhs) {
   check_string(lhs)
   check_string(rhs)
   paste0(lhs, rhs)
 }
 
-pluck <- function(list, idx) list[[idx]]
+snake_case <- function(x) {
+  check_string(x)
+  x <- tolower(x)
+  gsub(".", "_", x, fixed = TRUE)
+}
+
+pluck <- function(list, idx)
+  list[[idx]][[1]]
+
+patch_pxR <- function(tmp_loc) {
+  # ADD FIX. see: https://github.com/cjgb/pxR/issues/1#issuecomment-800023341
+  fix <-
+    iconv(
+      readLines(tmp_loc, encoding = "CP1252"),
+      from = "CP1252",
+      to = "Latin1",
+      sub = ""
+    )
+  fix <- gsub('\"......\"', '\"....\"', fix, fixed = TRUE)
+  fix <- gsub('\".....\"', '\"....\"', fix, fixed = TRUE)
+  writeLines(fix, con = tmp_loc, useBytes = TRUE)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,7 @@
+`%+%` <- function(lhs, rhs) {
+  check_string(lhs)
+  check_string(rhs)
+  paste0(lhs, rhs)
+}
+
+pluck <- function(list, idx) list[[idx]]


### PR DESCRIPTION
Hi Félix

I really liked your package but also had an issue with #3 

As you marked `help wanted`, I thought I could have a look.

I think the issue had to do the the use of `file.path()` which already adds a path separator according to the platform linux/windows.

I found `main.R` a bit difficult to read, so I refactored a bit and in doing so I confirmed that value translation is still buggy and therefore I removed it for the time being.

I will still try to have a go at value translation on a separate pull request, but I thought you could find the following changes to be useful in the meantime.

I would be curious to see whether the proposed changes work on windows.

Thanks!